### PR TITLE
docs: update trial license link to docs.scanbot.io/trial/

### DIFF
--- a/DocumentRTUUI/DocumentScannerRTUUIExample/Helpers/Cells/BannerUITableViewCell.swift
+++ b/DocumentRTUUI/DocumentScannerRTUUIExample/Helpers/Cells/BannerUITableViewCell.swift
@@ -16,7 +16,7 @@ class BannerUITableViewCell: UITableViewCell {
     }
     
     @IBAction func getLicenseTapped(_ sender: UIButton) {
-        if let url = URL(string: "https://scanbot.io/trial/") {
+        if let url = URL(string: "https://docs.scanbot.io/trial/") {
             UIApplication.shared.open(url)
         }
     }

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ As a customer, you also get access to a dedicated support Slack or Microsoft Tea
 
 The Scanbot SDK examples will run one minute per session without a license. After that, all functionalities and UI components will stop working. 
 
-To try the Scanbot SDK without the one-minute limit, you can request a free, no-strings-attached [7-day](https://scanbot.io/trial/?utm_source=github.com&utm_medium=referral&utm_campaign=dev_sites) trial license.
+To try the Scanbot SDK without the one-minute limit, you can request a free, no-strings-attached [7-day](https://docs.scanbot.io/trial/?utm_source=github.com&utm_medium=referral&utm_campaign=dev_sites) trial license.
 
 Alternatively, check out our [demo apps](https://scanbot.io/demo-apps/?utm_source=github.com&utm_medium=referral&utm_campaign=dev_sites) to test the SDK.
 


### PR DESCRIPTION
## Summary
- Same stale-link cleanup as [doo/scanbot-sdk-example-android#433](https://github.com/doo/scanbot-sdk-example-android/pull/433): the old `scanbot.io/trial/` link is replaced with `docs.scanbot.io/trial/` in README.md and the in-app "Get License" banner action.

## Test plan
- Docs-only change, no build impact.